### PR TITLE
New Feature: Make it possible to disable console.info messages for extractFromURL function

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ import unpacker from 'tarball-unpacker'
 
 // Specify a URL and target directory
 unpacker
-  .extractFromFile('http://www.arkaitzgarro.com/tarball.tgz', '/tmp/destination')
+  .extractFromURL('http://www.arkaitzgarro.com/tarball.tgz', '/tmp/destination')
   .then((files) => {
     console.log(files) // An array of unpacked paths to files
     console.log('Done!')
@@ -71,7 +71,7 @@ import {Unpacker} from 'tarball-unpacker'
 const unpacker = new Unpacker()
 
 unpacker
-  .extractFromFile('http://www.arkaitzgarro.com/tarball.tgz', '/tmp/destination')
+  .extractFromURL('http://www.arkaitzgarro.com/tarball.tgz', '/tmp/destination')
   .then(() => {
     console.log('Done!')
   })

--- a/src/unpacker.js
+++ b/src/unpacker.js
@@ -60,6 +60,8 @@ class Unpacker {
    * @return {Promise}
    */
   extractFromURL (url, destinationFolder) {
+    this._logger('Conecting to: ' + url)
+
     const _extractFromURL = function _extractFromURL (resolve, reject) {
       const req = http.get(url, function (response) {
         if (response.statusCode !== 200) {

--- a/src/unpacker.js
+++ b/src/unpacker.js
@@ -56,9 +56,11 @@ class Unpacker {
    * @param  {String}  url URL to tarball file
    * @return {Promise}
    */
-  extractFromURL (url, destinationFolder) {
+  extractFromURL (url, destinationFolder, options = {}) {
+    const silent = options.silent || false
+
     const _extractFromURL = function _extractFromURL (resolve, reject) {
-      console.info('Conecting to: ' + url)
+      if (!silent) console.info('Conecting to: ' + url)
 
       const req = http.get(url, function (response) {
         if (response.statusCode !== 200) {
@@ -66,9 +68,9 @@ class Unpacker {
           return
         }
 
-        console.info('Downloading file...')
+        if (!silent) console.info('Downloading file...')
 
-        this._extract(response, destinationFolder)
+        this._extract(response, destinationFolder, options)
           .then(resolve)
           .catch(reject)
       }.bind(this))
@@ -81,11 +83,13 @@ class Unpacker {
     return new Promise(_extractFromURL.bind(this))
   }
 
-  _extract (stream, destinationFolder) {
+  _extract (stream, destinationFolder, options = {}) {
+    const silent = options.silent || false
+
     const extract = function (resolve, reject) {
       const files = []
 
-      console.info('Extracting file into ' + destinationFolder)
+      if (!silent) console.info('Extracting file into ' + destinationFolder)
 
       stream
         .pipe(zlib.createGunzip())

--- a/src/unpacker.js
+++ b/src/unpacker.js
@@ -13,17 +13,20 @@ class Unpacker {
    */
   constructor () {
     this._options = {}
+    this._logger = console.info
   }
 
   /**
-   * Configure unpacker with decompression options
+   * Configure unpacker with options
    *
-   * @param  {Object} options Options for decompression
+   * @param  {Object} options Options
    * @return {Object}         Self instance
    */
-  configure (options) {
+  configure (options = {}) {
     // TODO: extend default instance properties
-    this._options = options || {}
+    this._options = options
+
+    if (options.silent === true) this._logger = () => {}
 
     return this
   }
@@ -56,21 +59,17 @@ class Unpacker {
    * @param  {String}  url URL to tarball file
    * @return {Promise}
    */
-  extractFromURL (url, destinationFolder, options = {}) {
-    const silent = options.silent || false
-
+  extractFromURL (url, destinationFolder) {
     const _extractFromURL = function _extractFromURL (resolve, reject) {
-      if (!silent) console.info('Conecting to: ' + url)
-
       const req = http.get(url, function (response) {
         if (response.statusCode !== 200) {
           reject(new Error('Response not OK: ' + response.statusCode))
           return
         }
 
-        if (!silent) console.info('Downloading file...')
+        this._logger('Downloading file...')
 
-        this._extract(response, destinationFolder, options)
+        this._extract(response, destinationFolder)
           .then(resolve)
           .catch(reject)
       }.bind(this))
@@ -83,13 +82,11 @@ class Unpacker {
     return new Promise(_extractFromURL.bind(this))
   }
 
-  _extract (stream, destinationFolder, options = {}) {
-    const silent = options.silent || false
-
+  _extract (stream, destinationFolder) {
     const extract = function (resolve, reject) {
       const files = []
 
-      if (!silent) console.info('Extracting file into ' + destinationFolder)
+      this._logger('Extracting file into ' + destinationFolder)
 
       stream
         .pipe(zlib.createGunzip())

--- a/test/unit/file-unpacker-test.js
+++ b/test/unit/file-unpacker-test.js
@@ -20,6 +20,10 @@ describe('File unpacker test:', () => {
     expect(unpacker._options).to.be.empty
   })
 
+  it('logger is set', () => {
+    expect(unpacker._logger).to.not.be.undefined
+  })
+
   it('file not exist', (done) => {
     unpacker.extractFromFile('/non-existant.file', '/tmp')
       .catch(() => {

--- a/test/unit/url-unpacker-test.js
+++ b/test/unit/url-unpacker-test.js
@@ -22,6 +22,10 @@ describe('URL unpacker test:', () => {
     expect(unpacker._options).to.be.empty
   })
 
+  it('logger is set', () => {
+    expect(unpacker._logger).to.not.be.undefined
+  })
+
   it('url doesn not exist', (done) => {
     unpacker.extractFromURL('http://www.google.com/non-existant.file', '/tmp')
       .catch(() => {


### PR DESCRIPTION
Sometimes it would be nice to disable the `console.info` noise produced by this package. I Added a _optional_ `option` paramenter to the `extractFromURL` function to do that. Now you can call the function like this

``` javascript
unpacker.extractFromURL('http://www.arkaitzgarro.com/tarball.tgz', '/tmp/destination', { silent: true })
```

to disable the log messages. 
